### PR TITLE
Add contentType to s3

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -56,7 +56,8 @@ exports.upload = function(opts){
     putParams = {
       Bucket: BUCKET,
       Key: opts.dest,
-      Body: data
+      Body: data,
+      ContentType: opts.mime
     };
 
     client.putObject(putParams, function(err){


### PR DESCRIPTION
For whatever reason our source images didn't have content types set, this just ensures that the served file gets the correct contentType. You may also consider adding ACL:'public-read' or making it an option because our default policy is locked down.
