### PR TITLE
fix development port setting and cropfill for non-square

### DIFF
--- a/src/config/development.js
+++ b/src/config/development.js
@@ -12,7 +12,7 @@ module.exports = function(app){
 
   app.set('views', env.LOCAL_FILE_PATH + '/test');
   app.engine('html', require('ejs').renderFile);
-  app.set('port', process.env.PORT || 3001);
+  app.set('port', env.PORT || 3001);
   app.use(morgan('dev'));
   app.use(errorHandler());
 

--- a/src/lib/dimensions.js
+++ b/src/lib/dimensions.js
@@ -90,30 +90,26 @@ exports.cropFill = function(modifiers, size){
     modifiers.height = modifiers.width;
   }
 
-  if (size.width >= size.height) {
-    // need to check for situations where the requested size is bigger
-    // than the original dimension.
-    if (modifiers.height > size.height) {
-      cropWidth = cropHeight = size.height;
-    } else {
-      cropWidth = cropHeight = modifiers.height;
-    }
-
-    ht = newHt = cropHeight;
-    wd = null;
-    newWd = ht / size.height * size.width;
+  if (modifiers.width > size.width && modifiers.height <= size.height) {
+    cropWidth = size.width;
+    cropHeight = modifiers.height;
+  } else if (modifiers.width <= size.width && modifiers.height > size.height) {
+    cropWidth = modifiers.width;
+    cropHeight = size.height;
+  } else if (modifiers.width > size.width && modifiers.height > size.height) {
+    cropWidth = size.width;
+    cropHeight = size.height;
+  } else {
+    cropWidth = modifiers.width;
+    cropHeight = modifiers.height;
   }
 
-  else {
-    if (modifiers.width > size.width) {
-      cropWidth = cropHeight = size.width;
-    } else {
-      cropWidth = cropHeight = modifiers.width;
-    }
+  wd = newWd = cropWidth;
+  ht = newHt = Math.round(newWd*(size.height/size.width));
 
-    ht = null;
-    wd = newWd = cropWidth;
-    newHt = wd / size.width * size.height;
+  if(newHt < cropHeight) {
+    ht = newHt = cropHeight;
+    wd = newWd = Math.round(newHt*(size.width/size.height));
   }
 
   // get the crop X/Y as defined by the gravity or x/y modifiers
@@ -132,3 +128,4 @@ exports.cropFill = function(modifiers, size){
     }
   };
 };
+

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
 <body>
 
   <h2>Square</h2>
-  <p><a href="/test/sample_images/image1.jpg">Original</a></p>
+  <p><a href="/elocal/test/sample_images/image1.jpg">Original</a></p>
 
   <div class="sample-img">
     <img src="/s200-elocal/test/sample_images/image1.jpg">
@@ -51,6 +51,18 @@
   <div class="sample-img">
     <img src="/w200-ccut-gne-elocal/test/sample_images/image2.jpg">
     <p>w200-ccut-gne</p>
+  </div>
+
+  <h2>Non-Square Crop Fill</h2>
+
+  <div class="sample-img">
+    <img src="/w200-h150-cfill-elocal/test/sample_images/image1.jpg">
+    <p>w200-h150-cfill</p>
+  </div>
+
+  <div class="sample-img">
+    <img src="/w150-h200-cfill-elocal/test/sample_images/image1.jpg">
+    <p>w150-h200-cfill</p>
   </div>
 
   <h2>Height</h2>


### PR DESCRIPTION
1) the crop fill option was not working correctly for non-square dimensions
2) the development port setting was ignored so always defaulted to 3001
3) broken image in /test/index.html for original photo
4) added a couple of tests for non-squares in /test/index.html
