### PR TITLE
Added MAX_IMAGE_DIMENSION environment variable for limiting max image size

### DIFF
--- a/src/config/environment_vars.js
+++ b/src/config/environment_vars.js
@@ -25,6 +25,11 @@ vars = {
   AUTO_ORIENT: true,
   REMOVE_METADATA: true,
 
+  // Protect original files
+  // by specifying a max image width
+  // or height - limits max height/width in parameters
+  MAX_IMAGE_DIMENSION: null,
+
   // Optimization options
   JPEG_PROGRESSIVE: true,
   PNG_OPTIMIZER: 'pngquant',

--- a/src/image.js
+++ b/src/image.js
@@ -85,7 +85,7 @@ Image.prototype.parseUrl = function(request){
 
   // if the request is for no modification or metadata then assume the s3path
   // is the entire request path
-  if (_.indexOf(['original', 'json'], this.modifiers.action) > -1){
+  if (_.indexOf(['original', 'json', 'resizeOriginal'], this.modifiers.action) > -1){
     if (this.modifiers.external){
       parts.shift();
       this.path = parts.join('/');

--- a/src/streams/resize.js
+++ b/src/streams/resize.js
@@ -57,6 +57,7 @@ module.exports = function(){
     }
 
     switch(image.modifiers.action){
+    case 'resizeOriginal':
     case 'resize':
       r.resize(image.modifiers.width, image.modifiers.height);
       r.stream(streamResponse);


### PR DESCRIPTION
This is a form of protecting the original resolution images, by inserting
an environment variable that limits the maximum width or height to this dimension

If the environment variable is not set, no upper limit will be imposed.

modifiers.js unit test altered to allow injection of environment variables.