### PR TITLE
Restrict image size on resize

### DIFF
--- a/src/streams/resize_sharp.js
+++ b/src/streams/resize_sharp.js
@@ -67,6 +67,7 @@ module.exports = function () {
 
     case 'resize':
       r.resize(image.modifiers.width, image.modifiers.height);
+      r.max();
       r.toBuffer(resizeResponse);
       break;
 
@@ -107,6 +108,7 @@ module.exports = function () {
         switch(image.modifiers.crop){
         case 'fit':
           r.resize(image.modifiers.width, image.modifiers.height);
+          r.max();
           break;
         case 'fill':
           d = dims.cropFill(image.modifiers, size);


### PR DESCRIPTION
# Problem

[Sharp's default resize][sharp-resize] also crops a given image. If you have a 200x200 image and request `w:100 h:200 c:fit` it will return a 100x200 image. GM will return a 100x100 image.

To get the 100x200 image from Sharp you can explicitly ask with `w:100 h:200 c:fill`.

# Solution

[gm's `resize`][gm-resize] method will preserve aspect ratio by default:

[sharp's `resize`][sharp-resize] acts the opposite and will crop to the exact size. Adding `max()` tells sharp to preserve the aspect ratio, reproducing the original gm functionality.

[gm-resize]: http://aheckmann.github.io/gm/docs.html#resize
[sharp-resize]: https://github.com/lovell/sharp#resizewidth-height