### PR TITLE
Padding crop modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ Modifiers are a dash delimited string of the requested modifications to be made,
 * scale
     * do not maintain original proportions
     * force image to be new dimensions (squishing the image)
+* pad
+    * maintain original proportions
+    * resize so image fits wholly into new dimensions
+    * padding added on top/bottom or left/right as needed (color is configurable)
+
 
 *Examples:*
 * `http://my.cdn.com/s50/path/to/image.png`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The available variables are as follows:
   // max height/width in parameters
   MAX_IMAGE_DIMENSION: null,
 
+  // Color used when padding an image with the 'pad' crop modifier.
+  IMAGE_PADDING_COLOR: 'white',
+
   // Optimization options
   IMAGE_QUALITY: 80,
   IMAGE_PROGRESSIVE: true,

--- a/src/config/environment_vars.js
+++ b/src/config/environment_vars.js
@@ -30,6 +30,7 @@ vars = {
   // or height - limits max height/width in parameters
   MAX_IMAGE_DIMENSION: null,
 
+  // Color used when padding an image with the 'pad' crop modifier.
   IMAGE_PADDING_COLOR: 'white',
 
   // Optimization options

--- a/src/config/environment_vars.js
+++ b/src/config/environment_vars.js
@@ -30,6 +30,8 @@ vars = {
   // or height - limits max height/width in parameters
   MAX_IMAGE_DIMENSION: null,
 
+  IMAGE_PADDING_COLOR: 'white',
+
   // Optimization options
   IMAGE_PROGRESSIVE: true,
   IMAGE_QUALITY: 80,

--- a/src/lib/modifiers.js
+++ b/src/lib/modifiers.js
@@ -40,6 +40,10 @@ Crop modifiers:
   scale
      - do not maintain original proportions
      - force image to be new dimensions (squishing the image)
+  pad
+     - maintain original proportions
+     - resize so image fits wholly into new dimensions
+     - padding added on top/bottom or left/right as needed (color is configurable)
 
 */
 'use strict';
@@ -95,7 +99,7 @@ modifierMap = [
     key: 'c',
     desc: 'crop',
     type: 'string',
-    values: ['fit','fill','cut','scale'],
+    values: ['fit','fill','cut','scale','pad'],
     default: 'fit'
   },
   {

--- a/src/streams/resize.js
+++ b/src/streams/resize.js
@@ -140,6 +140,11 @@ module.exports = function () {
           // TODO: deal with scale
           r.resize(image.modifiers.width, image.modifiers.height);
           break;
+        case 'pad':
+          r.resize(
+            image.modifiers.width,
+            image.modifiers.height
+          ).background(env.IMAGE_PADDING_COLOR || 'white').embed();
         }
 
         r.toBuffer(resizeResponse);

--- a/test/index.html
+++ b/test/index.html
@@ -50,6 +50,11 @@
   </div>
 
   <div class="sample-img">
+    <img src="/w200-h200-cpad-elocal/test/sample_images/image2.jpg">
+    <p>w200-h200-cpad</p>
+  </div>
+
+  <div class="sample-img">
     <img src="/w200-cfill-elocal/test/sample_images/image2.jpg">
     <p>w200-cfill</p>
   </div>


### PR DESCRIPTION
Hey James. First off, thanks for your work on image-resizer. It has been a great starting point for us.

So, a common task we get is to be able to maintain an image's proportions while resizing it, but having the resulting image be of whatever dimensions you've provided. So if you have a 600x600 image, you could request w300-h400-cpad, which results in a 300x400 image, with white bars filling in the rest of the image (in this case on the top/bottom, but can be on the left/right). Turns out this is handled really easily by sharp. By default I've set this value to white as that's what we commonly use, but it's in the config so it could be any valid color that can be passed to sharp.

Transparency would be nice, but that would only work for certain formats. Adding a way to check for formats that support this would be a cool addition. For our purposes, having the color defined has historically been enough. It basically just helps us spit out images with the right dimensions without having to worry about alignment.

The changes for this part are pretty minimal. Hope you find this to be a useful feature. I added an example to /test-page that might do a better job explaining this than I did.

The other feature I've got some code for is doing local disk caching. I won't go into details now, but for future reference, what's your preferred method for discussing these? Github Issue? Let me know.

Thanks again