### PR TITLE
Passing values over sharp's width/height limit of 16383 causes crash.

### DIFF
--- a/src/lib/modifiers.js
+++ b/src/lib/modifiers.js
@@ -158,16 +158,26 @@ function parseModifiers(mods, modArr) {
     value = item.slice(1);
 
     if (inArray(key, modKeys)){
-
+      
       // get the modifier object that responds to the listed key
       mod = getModifier(key);
+
+      //this is a limit enforced by sharp. the application will crash without
+      //these checks.
+      var dimensionLimit = 16383;
 
       switch(mod.desc){
       case 'height':
         mods.height = string.sanitize(value);
+        if (mods.height > dimensionLimit) {
+          mods.height = dimensionLimit;
+        }
         break;
       case 'width':
         mods.width = string.sanitize(value);
+        if (mods.width > dimensionLimit) {
+          mods.width = dimensionLimit;
+        }
         break;
       case 'square':
         mods.action = 'square';


### PR DESCRIPTION
I set up an instance of image-resizer recently and showed a friend, who immediately entered a width of 90000 pixels. I figured it would just return the original image, but the actual behavior is that the values are passed across to sharp, which has a strict limit of 16383 (for both width and height) and throws an exception, causing a crash. I figured a more sensible response was to simply set them to the max if either one is over the threshold, which results in getting the original image back.

I simply added a couple checks for this within modifiers.js where parameters are sanitized to prevent this from being a problem.

To replicate, simply start the application and use something like w90000 or h90000. This doesn't appear to affect the 'square' modifier, likely because of the calculations being done in dimensions.js (cropFill)

Let me know if any additional changes are needed.