### PR TITLE
Add `q` image quality modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ The available variables are as follows:
 
 ## Optimization
 
-Optimization of images is done via [sharp](https://github.com/lovell/sharp#qualityquality). The variables to set are:
+Optimization of images is done via [sharp](https://github.com/lovell/sharp#qualityquality). The environment variables to set are:
 
-* `IMAGE_QUALITY`:  0 - 100
+* `IMAGE_QUALITY`:  1 - 100
 * `IMAGE_PROGRESSIVE`:  true | false
 
+You may also adjust the image quality setting per request with the `q` quality modifier described below.
 
 ## CDN
 
@@ -165,6 +166,7 @@ Modifiers are a dash delimited string of the requested modifications to be made,
 * gravity:      eg. gs, gne
 * filter:       eg. fsepia
 * external:     eg. efacebook
+* quality:      eg. q90
 
 *Crop modifiers:*
 * fit

--- a/src/lib/modifiers.js
+++ b/src/lib/modifiers.js
@@ -22,6 +22,7 @@ Supported modifiers are:
   - gravity:      eg. gs, gne
   - filter:       eg. fsepia
   - external:     eg. efacebook
+  - quality:      eg. q90
 
 Crop modifiers:
   fit
@@ -114,6 +115,13 @@ modifierMap = [
     desc: 'filter',
     type: 'string',
     values: filterKeys
+  },
+  {
+    key: 'q',
+    desc: 'quality',
+    type: 'integer',
+    range: [1, 100],
+    default: environment.IMAGE_QUALITY
   }
 ];
 
@@ -214,6 +222,14 @@ function parseModifiers(mods, modArr) {
           mods.filter = value.toLowerCase();
         }
         break;
+      case 'quality':
+        value = string.sanitize(value);
+        if(!isNaN(value)) {
+          var min = mod.range[0],
+            max = mod.range[1];
+          mods.quality = Math.max(min, Math.min(max, value));
+        }
+        break;
       }
 
     }
@@ -269,10 +285,11 @@ exports.parse = function(requestUrl, namedMods, envOverride){
     env = _.clone(environment);
   }
 
-  var segments, mods, modStr, image, gravity, crop;
+  var segments, mods, modStr, image, gravity, crop, quality;
 
   gravity   = getModifier('g');
   crop      = getModifier('c');
+  quality   = getModifier('q');
   segments  = requestUrl.replace(/^\//,'').split('/');
   modStr    = _.first(segments);
   image     = _.last(segments).toLowerCase();
@@ -285,7 +302,8 @@ exports.parse = function(requestUrl, namedMods, envOverride){
     height: null,
     width: null,
     gravity: gravity.default,
-    crop: crop.default
+    crop: crop.default,
+    quality: quality.default
   };
 
   // check the request to see if it includes a named modifier

--- a/src/streams/optimize.js
+++ b/src/streams/optimize.js
@@ -28,8 +28,8 @@ module.exports = function () {
       r.progressive();
     }
 
-    if (env.IMAGE_QUALITY < 100) {
-      r.quality(env.IMAGE_QUALITY);
+    if (image.modifiers.quality < 100) {
+      r.quality(image.modifiers.quality);
     }
 
     r.toBuffer( function (err, buffer) {

--- a/test/src/lib/modifiers-spec.js
+++ b/test/src/lib/modifiers-spec.js
@@ -179,4 +179,38 @@ describe('Modifiers module', function(){
 
   });
 
+  // Quality
+  describe('Quality requests', function(){
+    it('should leave the action as original', function(){
+      var request = '/q90/path/to/image.png';
+      mod.parse(request).action.should.equal('original');
+    });
+    it('should set the quality', function(){
+      var request = '/q90/image.png',
+        p = mod.parse(request);
+      expect(p.quality).to.equal(90);
+    });
+    it('should clamp out of range quality values', function(){
+      var request, p;
+
+      request = '/q101/image.png';
+      p = mod.parse(request);
+      expect(p.quality).to.equal(100);
+
+      request = '/q0/image.png';
+      p = mod.parse(request);
+      expect(p.quality).to.equal(1);
+    });
+    it('should use environment for default quality value', function(){
+      var request = '/image.png',
+        p = mod.parse(request);
+      expect(p.quality).to.equal(env.IMAGE_QUALITY);
+    });
+    it('should ignore invalid quality value', function(){
+      var request = '/qinvalid/image.png',
+        p = mod.parse(request);
+      expect(p.quality).to.equal(env.IMAGE_QUALITY);
+    });
+  });
+
 });


### PR DESCRIPTION
This PR lets you set the quality setting through the `q` modifier in the path, allowing more fine-grained customization than the existing `IMAGE_QUALITY` environment variable that applies the same quality setting to all images.