### PR TITLE
Explicit output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ While `image-resizer` will work as a standalone app, almost all of its facility 
 
 A couple of routes are included with the default app, but the most important is the image generation one, which is as follows:
 
-`http://my.cdn.com/:modifiers/path/to/image.png[:metadata]`
+`http://my.cdn.com/:modifiers/path/to/image.png[:format][:metadata]`
 
 Modifiers are a dash delimited string of the requested modifications to be made, these include:
 
@@ -223,6 +223,13 @@ A shorter expiry on images from social sources can also be set via `IMAGE_EXPIRY
 
 It is also trivial to write new source streams via the plugins directory. Examples are in `src/streams/sources/`.
 
+## Output format
+
+You can convert images to another image format by appending an extra extension to the image path:
+
+* `http://my.cdn.com/path/to/image.png.webp`
+
+JPEG (`.jpg`/`.jpeg`), PNG (`.png`), and WEBP (`.webp`) output formats are supported.
 
 ## Metadata requests
 

--- a/src/image.js
+++ b/src/image.js
@@ -58,10 +58,9 @@ function Image(request){
   this.log = new Logger();
 }
 
-
-Image.validFormats = ['jpeg', 'jpg', 'gif', 'png'];
+Image.validInputFormats = ['jpeg', 'jpg', 'gif', 'png', 'webp'];
+Image.validFormats = ['jpeg', 'png', 'webp'];
 Image.formatErrorText = 'not valid image format';
-
 
 // Determine the name and format of the requested image
 Image.prototype.parseImage = function(request){
@@ -70,7 +69,21 @@ Image.prototype.parseImage = function(request){
   // clean out any metadata format
   fileStr = fileStr.replace(/.json$/, '');
 
-  this.format = _.last(fileStr.split('.')).toLowerCase();
+  var exts = fileStr.split('.');
+  this.format = _.last(exts).toLowerCase();
+  if(this.format === 'jpg') {
+    this.format = 'jpeg';
+  }
+
+  // if path contains valid input and output format extensions, remove the output format from path
+  if(exts.length > 1) {
+    var inputFormat = exts[exts.length - 2].toLowerCase();
+    if (_.indexOf(Image.validFormats, this.format) !== -1 &&
+      _.indexOf(Image.validInputFormats, inputFormat) !== -1){
+      fileStr = exts.slice(0, -1).join('.');
+    }
+  }
+
   this.image  = fileStr;
 };
 

--- a/src/streams/optimize.js
+++ b/src/streams/optimize.js
@@ -32,6 +32,8 @@ module.exports = function () {
       r.quality(env.IMAGE_QUALITY);
     }
 
+    r.toFormat(image.format);
+
     r.toBuffer( function (err, buffer) {
       if (err) {
         image.log.error('optimize error', err);

--- a/test/src/image-spec.js
+++ b/test/src/image-spec.js
@@ -12,7 +12,7 @@ describe('Image class', function(){
   describe('#parseImage()', function(){
     it('should determine the format from the request', function(){
       var img = new Img({path: '/path/to/image.jpg'});
-      img.format.should.equal('jpg');
+      img.format.should.equal('jpeg');
     });
 
     it('should normalise the format from the request', function(){
@@ -22,7 +22,7 @@ describe('Image class', function(){
 
     it('should still get format from a metadata request', function(){
       var img = new Img({path: '/path/to/image.jpg.json'});
-      img.format.should.equal('jpg');
+      img.format.should.equal('jpeg');
     });
 
     it('should retrieve image name from the path', function(){
@@ -68,6 +68,14 @@ describe('Image class', function(){
       var perioded = '8b0ccce0.0a6c.4270.9bc0.8b6dfaabea19.jpg',
           img = new Img({path: '/path/to/' + perioded + '.json'});
       img.image.should.equal(perioded);
+    });
+
+    it('should exclude second output format from image path', function(){
+      var image = 'image.jpg',
+        img = new Img({path: '/path/to/' + image + '.webp'});
+      img.format.should.equal('webp');
+      img.image.should.equal(image);
+      img.path.should.equal('/path/to/' + image);
     });
 
   });


### PR DESCRIPTION
This PR adds the ability to specify an explicit image output format (using sharp's [`toFormat`](https://github.com/lovell/sharp#toformatformat) function) by appending an extra image extension to the path, e.g. to convert a PNG image to WEBP output, you could specify:

```
http://my.cdn.com/path/to/image.png.webp
```

Somewhat related to the feature request in #55 (part 2).