### PR TITLE
Allowing enlargement when generating padded images.

### DIFF
--- a/src/streams/resize.js
+++ b/src/streams/resize.js
@@ -43,8 +43,12 @@ module.exports = function () {
 
     var r = sharp(image.contents);
 
-    // never enlarge an image beyonds its original size
-    r.withoutEnlargement();
+    // never enlarge an image beyond its original size, unless we're padding
+    // the image, as even though this can count as an "enlargement" the padded
+    // result can be reasonably generated in most cases.
+    if (image.modifiers.action !== 'crop' && image.modifiers.crop !== 'pad') {
+      r.withoutEnlargement();
+    }
 
     // if allowed auto rotate images, very helpful for photos off of an iphone
     // which are landscape by default and the metadata tells them what to show.


### PR DESCRIPTION
I've been running into an issue with padded images. Basically, if either the requested width/height of the padded image is greater than the original dimensions, the original image is returned. This is problematic with things such as fairly small tall/wide images. The root of the problem seems to be on sharp's end, but I think this is a reasonable fix while the discussion on that repo is going on: https://github.com/lovell/sharp/issues/243