### PR TITLE
Add ability to require client request signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ The available variables are as follows:
   IMAGE_404: null
 
   // Whitelist arbitrary HTTP source prefixes using EXTERNAL_SOURCE_*
-  EXTERNAL_SOURCE_WIKIPEDIA: 'https://upload.wikimedia.org/wikipedia/'
+  EXTERNAL_SOURCE_WIKIPEDIA: 'https://upload.wikimedia.org/wikipedia/',
+
+  // Set a key used to force clients to sign requests (reduce risk of DDoS)
+  REQUEST_SIGNING_KEY: null
 ```
 
 
@@ -206,6 +209,23 @@ Modifiers are a dash delimited string of the requested modifications to be made,
 
 It is worthy of note that this application will not scale images up, we are all about keeping images looking good. So a request for `h400` on an image of only 200px in height will not scale it up.
 
+## Request signing
+
+If a REQUEST_SIGNING_KEY is set all requests to the application will require a signature to be passed as the first url segment. This is used to verify the client is allowed to make the request. Request signing can reduce the risk DDoS. It's a simple mechanism to validate requests are coming from trusted clients.
+
+The following PHP method is an example of how can client can generate valid a signature:
+
+```
+<?php
+function createSignature($str) {
+  $hash = base64_encode(hash_hmac('sha1', $str, 'secret key that is same as configure on image-resizer', true));
+  return substr(str_replace(['+', '/', '='], ['-', '_', 'e'], $hash), 0, 8);
+}
+
+var_dump(':modifiers/path/to/image.jpg');
+
+// <img src="http://cdn.site.com/<?php echo createSignature(':modifiers/path/to/image.jpg'); ?>/:modifiers/path/to/image.jpg" alt="">
+```
 
 ## S3 source
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ It is worthy of note that this application will not scale images up, we are all 
 
 If a REQUEST_SIGNING_KEY is set all requests to the application will require a signature to be passed as the first url segment. This is used to verify the client is allowed to make the request. Request signing can reduce the risk DDoS. It's a simple mechanism to validate requests are coming from trusted clients.
 
-The following PHP method is an example of how can client can generate valid a signature:
+The following PHP method is an example of how a client can generate valid a signature:
 
 ```
 <?php

--- a/src/config/environment_vars.js
+++ b/src/config/environment_vars.js
@@ -62,7 +62,7 @@ vars = {
   IMAGE_404: null,
 
   // Whitelist arbitrary HTTP source prefixes using EXTERNAL_SOURCE_*
-  EXTERNAL_SOURCE_WIKIPEDIA: 'https://upload.wikimedia.org/wikipedia/'
+  EXTERNAL_SOURCE_WIKIPEDIA: 'https://upload.wikimedia.org/wikipedia/',
 
   // Set a key used to force clients to sign requests (reduce risk of DDoS)
   REQUEST_SIGNING_KEY: null

--- a/src/config/environment_vars.js
+++ b/src/config/environment_vars.js
@@ -59,8 +59,10 @@ vars = {
   LOCAL_FILE_PATH: process.cwd(),
 
   // Display an image if a 404 request is encountered from a source
-  IMAGE_404: null
+  IMAGE_404: null,
 
+  // Set a key used to force clients to sign requests (reduce risk of DDoS)
+  REQUEST_SIGNING_KEY: null
 };
 
 _.forEach(vars, function(value, key){

--- a/src/image.js
+++ b/src/image.js
@@ -37,6 +37,7 @@ function Image(request){
   // reject this request if the image format is not correct
   if (_.indexOf(Image.validFormats, this.format) === -1){
     this.error = new Error(Image.formatErrorText);
+    this.error.statusCode = 404;
   }
 
   // determine the requested modifications


### PR DESCRIPTION
I'm not sure if anyone is interested in this functionality but will add a PR in case people are. 

I've added the ability to force clients to pass a signature in with all requests. 

This is a cheap way to validate that requests are coming form trusted sources. It's not completely foolproof and is a bit of security through obscurity however it will stop someone from looping through every possible modifier and requesting sizes that differ by 1px. This would put a lot of load on the server and if done by a botnet could DDoS the service.

Simply set a REQUEST_SIGNING_KEY to be a long string. Share this key with your clients and the algorithm used to create signatures. 

If image-resizer sees that a REQUEST_SIGNING_KEY is set it will compare the signature with the requested image/modifier options and make sure there is a match. If no match is found a 404 is returned.

I've also changed image.js to return a 404 if a request comes in for an unsupported format. This seems more logical to me than returning a 500.