### PR TITLE
Issue Fixes - 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ The `.buildpacks` file will then take care of the installation process.
 
 As mentioned above there is a minimum set of config vars that need to be set before `image-resizer` runs correctly.
 
+It is also of note that due to some issues with GCC, `sharp` can not be used on the older Heroku stacks. Currently it requires `cedar-14` stack.
+
 
 ## Local development
 

--- a/bin/image_resizer.js
+++ b/bin/image_resizer.js
@@ -62,7 +62,8 @@ function createApplicationAt(dir){
       'image-resizer': '~' + pkg.version,
       'express': pkg.dependencies.express,
       'lodash': pkg.dependencies.lodash,
-      'chalk': pkg.dependencies.chalk
+      'chalk': pkg.dependencies.chalk,
+      'sharp': pkg.dependencies.sharp
     },
     devDependencies: pkg.devDependencies
   };

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "optimization"
   ],
   "author": "James Nicol <james.andrew.nicol@gmail.com> (https://github.com/jimmynicol)",
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/jimmynicol/image-resizer/raw/master/LICENSE"
-  },
+  "license": "MIT",
   "repository": "git://github.com/jimmynicol/image-resizer",
   "bin": {
     "image-resizer": "./bin/image_resizer.js"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "errorhandler": "^1.0.1",
     "express": "^4.9.7",
     "glob": "~3.2.9",
+    "image-type": "^2.0.2",
     "lodash": "~2.4.1",
     "map-stream": "~0.1.0",
     "mkdirp": "^0.5.0",

--- a/src/config/environment_vars.js
+++ b/src/config/environment_vars.js
@@ -25,9 +25,8 @@ vars = {
   AUTO_ORIENT: true,
   REMOVE_METADATA: true,
 
-  // Protect original files
-  // by specifying a max image width
-  // or height - limits max height/width in parameters
+  // Protect original files by specifying a max image width or height - limits
+  // max height/width in parameters
   MAX_IMAGE_DIMENSION: null,
 
   // Color used when padding an image with the 'pad' crop modifier.

--- a/src/streams/optimize.js
+++ b/src/streams/optimize.js
@@ -28,12 +28,17 @@ module.exports = function () {
       r.progressive();
     }
 
+    // set the output quality
     if (image.modifiers.quality < 100) {
       r.quality(image.modifiers.quality);
     }
 
-    r.toFormat(image.format);
+    // if a specific output format is specified, set it
+    if (image.outputFormat) {
+      r.toFormat(image.outputFormat);
+    }
 
+    // write out the optimised image to buffer and pass it on
     r.toBuffer( function (err, buffer) {
       if (err) {
         image.log.error('optimize error', err);

--- a/src/streams/sources/external.js
+++ b/src/streams/sources/external.js
@@ -31,7 +31,7 @@ util.inherits(External, stream.Readable);
 External.prototype._read = function(){
   var _this = this,
     url,
-    fbStream,
+    imgStream,
     bufs = [];
 
   if ( this.ended ){ return; }
@@ -47,24 +47,24 @@ External.prototype._read = function(){
 
   this.image.log.time(this.key);
 
-  fbStream = request.get(url);
-  fbStream.on('data', function(d){ bufs.push(d); });
-  fbStream.on('error', function(err){
+  imgStream = request.get(url);
+  imgStream.on('data', function(d){ bufs.push(d); });
+  imgStream.on('error', function(err){
     _this.image.error = new Error(err);
   });
-  fbStream.on('response', function(response) {
+  imgStream.on('response', function(response) {
     if (response.statusCode !== 200) {
       _this.image.error = new Error('Error ' + response.statusCode + ':');
     }
   });
-  fbStream.on('end', function(){
+  imgStream.on('end', function(){
     _this.image.log.timeEnd(_this.key);
     if(_this.image.isError()) {
       _this.image.error.message += Buffer.concat(bufs);
     } else {
       _this.image.contents = Buffer.concat(bufs);
+      _this.image.originalContentLength = contentLength(bufs);
     }
-    _this.image.originalContentLength = contentLength(bufs);
     _this.ended = true;
     _this.push(_this.image);
     _this.push(null);

--- a/test/index.html
+++ b/test/index.html
@@ -124,7 +124,7 @@
   </div>
 
   <div class="sample-img">
-    <img src="/h200-ewikipedia/en/7/70/Example.png">
+    <img src="/h200-ewikipedia/commons/c/c4/Louis_Armstrong2.jpg">
     <p>h200-ewikipedia</p>
   </div>
 

--- a/test/src/image-spec.js
+++ b/test/src/image-spec.js
@@ -2,6 +2,8 @@
 
 var chai = require('chai'),
     expect = chai.expect,
+    path = require('path'),
+    fs = require('fs'),
     Img = require('../../src/image');
 
 chai.should();
@@ -9,14 +11,10 @@ chai.should();
 
 describe('Image class', function(){
 
-  describe('#parseImage()', function(){
-    it('should determine the format from the request', function(){
-      var img = new Img({path: '/path/to/image.jpg'});
-      img.format.should.equal('jpeg');
-    });
-
+  describe('#format', function () {
     it('should normalise the format from the request', function(){
       var img = new Img({path: '/path/to/image.JPEG'});
+      img.format = 'JPEG'
       img.format.should.equal('jpeg');
     });
 
@@ -24,7 +22,20 @@ describe('Image class', function(){
       var img = new Img({path: '/path/to/image.jpg.json'});
       img.format.should.equal('jpeg');
     });
+  });
 
+  describe('#content', function () {
+    it ('should set the format based on the image data', function () {
+      var imgSrc = path.resolve(__dirname, '../sample_images/image1.jpg');
+      var buf = fs.readFileSync(imgSrc);
+      var img = new Img({path: '/path/to/image.jpg'});
+
+      img.contents = buf;
+      img.format.should.equal('jpeg');
+    });
+  });
+
+  describe('#parseImage', function(){
     it('should retrieve image name from the path', function(){
       var img = new Img({path: '/path/to/image.jpg'});
       img.image.should.equal('image.jpg');
@@ -70,18 +81,28 @@ describe('Image class', function(){
       img.image.should.equal(perioded);
     });
 
-    it('should exclude second output format from image path', function(){
-      var image = 'image.jpg',
-        img = new Img({path: '/path/to/' + image + '.webp'});
-      img.format.should.equal('webp');
-      img.image.should.equal(image);
-      img.path.should.equal('/path/to/' + image);
-    });
+    describe('#outputFormat', function () {
+      it('should exclude second output format from image path', function(){
+        var image = 'image.jpg',
+            img = new Img({path: '/path/to/' + image + '.webp'});
+        img.outputFormat.should.equal('webp');
+        img.image.should.equal(image);
+        img.path.should.equal('path/to/' + image);
+      });
 
+      it('should still get output format from perioded file name', function(){
+        var image = '8b0ccce0.0a6c.4270.9bc0.8b6dfaabea19.jpg',
+            img = new Img({path: '/path/to/' + image + '.webp'});
+        img.outputFormat.should.equal('webp');
+        img.image.should.equal(image);
+        img.path.should.equal('path/to/' + image);
+      });
+
+    });
   });
 
 
-  describe('#parseUrl()', function(){
+  describe('#parseUrl', function(){
     it('should return a clean path', function(){
       var img = new Img({path: '/path/to/image.jpg.json'});
       img.path.should.equal('path/to/image.jpg');
@@ -106,12 +127,12 @@ describe('Image class', function(){
   });
 
 
-  describe('bad formats', function(){
-    it('should set error if the format is not valid', function(){
-      var img = new Img({path: '/path/to/image.tiff'});
-      img.error.message.should.eq(Img.formatErrorText);
-    });
-  });
+  // describe('bad formats', function(){
+  //   it('should set error if the format is not valid', function(){
+  //     var img = new Img({path: '/path/to/image.tiff'});
+  //     img.error.message.should.eq(Img.formatErrorText);
+  //   });
+  // });
 
 
   it('should respond in an error state', function(){


### PR DESCRIPTION
Fixes for:

 - #55 : the image type checks are now done on the returned data and not via whitelisted extensions.
 - #57 : with the image type checks pushed back to the returned data, sources like s3 now handle the 404 errors on unknown requests directly.
 - #65 : `sharp` added to the generated app package.json so filters can work out of the box.

Also some other housekeeping.