### PR TITLE
Add brew install vips command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ When a new image size is requested of `image-resizer` via the CDN, it will pull 
 
 
 ## Getting Started
+When using Mac OS, make sure vips is installed:
+```
+$ brew install homebrew/science/vips
+```
+
+Then:
 
     $ npm install -g image-resizer gulp
     $ mkdir my_fancy_image_server


### PR DESCRIPTION
On macos, the vips library needs to be installed before doing the npm setup.
Otherwise npm install image-resizer will fail.
