### PR TITLE
Bump sharp to v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mkdirp": "^0.5.0",
     "morgan": "^1.0.1",
     "request": "~2.34.0",
-    "sharp": "^0.11.3",
+    "sharp": "^0.12.0",
     "twit": "~1.1.15"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #70 #81

Requires version bump (`1.3.1`?) so that the generated project's `package.json` uses the updated version.
